### PR TITLE
Add GA4 tracker

### DIFF
--- a/.github/workflows/CD-main-release.yaml
+++ b/.github/workflows/CD-main-release.yaml
@@ -33,6 +33,7 @@ jobs:
           NEWT_API_TOKEN: ${{ secrets.NEWT_API_TOKEN }}
           SPACE_UID: ${{ secrets.SPACE_UID }}
           APP_UID: ${{ secrets.APP_UID }}
+          NEXT_PUBLIC_GA_TAG_ID: ${{ vars.NEXT_PUBLIC_GA_TAG_ID }}
         run: yarn build
 
       - name: Add CNAME

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
+    "@types/gtag.js": "^0.0.17",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { SideBar } from "@/components/layouts/SideBar"
 import { Header } from "@/components/layouts/Header"
 import { Profile } from "@/components/elements/Profile"
 import { Main } from "@/components/layouts/Main"
+import { GATracking } from "@/components/features/GATracker"
 
 const inter = Noto_Sans_JP({ subsets: ["latin"] })
 
@@ -23,6 +24,9 @@ export const metadata = {
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang="ja">
+    <head>
+      <GATracking />
+    </head>
     <body className={inter.className}>
       <OutSideContainer>
         <SideBar />

--- a/src/components/features/GATracker/index.tsx
+++ b/src/components/features/GATracker/index.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { GA_TAG_ID } from "@/const/GA_TAG_ID"
+import { usePathname, useSearchParams } from "next/navigation"
+import Script from "next/script"
+import { FC, useEffect } from "react"
+import { dispatchPageView } from "./modules/dispatchPageView"
+
+export const GATracking: FC = () => {
+  const pathname = usePathname()
+  const searchParameters = useSearchParams()
+
+  useEffect(() => {
+    const url = pathname + searchParameters.toString()
+    dispatchPageView(url)
+  }, [pathname, searchParameters])
+
+  return process.env.NODE_ENV === "production" ? (
+    <>
+      <Script async strategy="lazyOnload" src={`https://www.googletagmanager.com/gtag/js?id=${GA_TAG_ID}`} />
+      <Script strategy="afterInteractive" id="ga-init">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_TAG_ID}', {
+            page_path: window.location.pathname,
+          });
+        `}
+      </Script>
+    </>
+  ) : // eslint-disable-next-line unicorn/no-null
+  null
+}

--- a/src/components/features/GATracker/modules/dispatchPageView/index.ts
+++ b/src/components/features/GATracker/modules/dispatchPageView/index.ts
@@ -1,0 +1,10 @@
+import { GA_TAG_ID } from "@/const/GA_TAG_ID"
+
+export const dispatchPageView = (path: string) => {
+  if (typeof window.gtag !== "function") return
+  if (!GA_TAG_ID) return
+
+  window.gtag("config", GA_TAG_ID, {
+    page_path: path,
+  })
+}

--- a/src/const/GA_TAG_ID/index.ts
+++ b/src/const/GA_TAG_ID/index.ts
@@ -1,0 +1,1 @@
+export const GA_TAG_ID = process.env.NEXT_PUBLIC_GA_TAG_ID || ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/gtag.js@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.17.tgz#4f84440e3424149517b41f60bd787374900d0b55"
+  integrity sha512-OsSO6Yyuygr3DeeTovOY0ppLiAVHoXg4CSanO9/vzDQCV+e8pkZNE+HR2dVxGJfUbtRe2IqzC97PYuHSNUepJw==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"


### PR DESCRIPTION
## 概要
This close #17 

## commits
- chore: run yarn add -D @types/gtag.js ( 929d3f6 )
- feat: define GA_TAG_ID enviroment variable ( 2f127fb )
- feat: implement dispatchPageView function ( b0b8aba )
- feat: implement GATracking component ( 7e55914 )
- chore: add NEXT_PUBLIC_GA_TAG_ID variable to deploy workflow ( 6746070 )